### PR TITLE
fix(blog): add raw tags to YAML block

### DIFF
--- a/app/_posts/2025-09-25-kuma-2-12.md
+++ b/app/_posts/2025-09-25-kuma-2-12.md
@@ -29,6 +29,8 @@ With MeshIdentity, you can:
 
 Whilst this provides SPIFFE-compliant practices, we also worked on being able to integrate with a SPIRE agent running on your Kubernetes nodes to be able to obtain their SPIFFE Verifiable Identity Documents:
 
+{% raw %}
+
 ```yaml
 apiVersion: kuma.io/v1alpha1
 kind: MeshIdentity
@@ -48,6 +50,8 @@ spec:
    type: Spire
    spire: {}
 ```
+
+{% endraw %}
 
 If you're using SPIRE, it's classed as the Trust authority for the mesh, and for customers that have not rolled out SPIRE in their organisations, we've also introduced the concept of MeshTrust.
 


### PR DESCRIPTION
## Motivation

Jekyll was attempting to render Jinja2-like syntax in YAML code block, causing rendering issues.

## Implementation information

Added `{% raw %}` tags around the YAML block containing `{{ spiffe_id }}` to prevent Jekyll from processing the content.

## Supporting documentation

N/A