### PR TITLE
fix(styles): replace deprecated Sass color functions

### DIFF
--- a/app/_assets/styles/custom/base/_forms.scss
+++ b/app/_assets/styles/custom/base/_forms.scss
@@ -2,6 +2,8 @@
 // Forms
 //
 
+@use 'sass:color';
+
 $input-height: 44px;
 
 // text inputs
@@ -112,7 +114,7 @@ button,
 .btn--hollow {
   $border-color: rgba($navy, 0.1);
   $border-color-dark: rgba($navy, 0.3);
-  $hover-color: lighten($color-5, 10);
+  $hover-color: color.scale($color-5, $lightness: 17.5862068966%);
 
   box-shadow: $base-soft-shadow, inset 0 0 0 1.5px $border-color;
 
@@ -147,7 +149,7 @@ button,
 
   &:hover,
   &:active {
-    background-color: lighten($color-13, 10);
+    background-color: color.scale($color-13, $lightness: 17.5862068966%);
   }
 
   @include button-state-overrides;

--- a/app/_assets/styles/custom/config/_mixins.scss
+++ b/app/_assets/styles/custom/config/_mixins.scss
@@ -1,4 +1,5 @@
 @use 'sass:math';
+@use 'sass:color';
 
 //
 // Mixins + Functions
@@ -87,7 +88,7 @@
   }
 
   &:hover {
-    background-color: lighten($green-base, 3.5);
+    background-color: color.scale($green-base, $lightness: 6.3523131673%);
   }
 }
 

--- a/app/_assets/styles/custom/config/_variables.scss
+++ b/app/_assets/styles/custom/config/_variables.scss
@@ -1,4 +1,5 @@
 @use 'sass:math';
+@use 'sass:color';
 
 //
 
@@ -25,7 +26,7 @@ $color-13: #290b53;
 
 $gray-1: #fdfdfd;
 $gray-2: #bfbfbf;
-$gray-3: lighten(#949494, 22);
+$gray-3: color.scale(#949494, $lightness: 52.4299065421%);
 $gray-4: #e1e1e1;
 $gray-5: #49494b;
 $gray-6: #f7f8f9;
@@ -34,7 +35,7 @@ $gray-8: #e5eaed;
 
 $navy: #062f4d;
 $navy-alt: #20242c;
-$navy-light: lighten($navy-alt, 74);
+$navy-light: color.scale($navy-alt, $lightness: 86.9585253456%);
 $sky: #e6edfa;
 $sky-light: #f1f5fc;
 


### PR DESCRIPTION
## Motivation

Sass deprecation warnings for color functions and mixed declarations appearing during builds.

## Implementation information

- Replaced deprecated `lighten()` and `darken()` with `color.scale()` in 4 SCSS files
- Fixed mixed-decls warnings by moving property declarations before `@include`/`@media` rules in 3 files
- Added `@use 'sass:color'` imports where needed

## Supporting documentation

N/A